### PR TITLE
remove 'jira' from subdomain

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   EC2-Deploy:
     # if the branch name of the PR does not contain 'skip-deploy'

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -24,6 +24,6 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
-        sub-domain: "timeline-report-${{ github.ref_name }}"
+        sub_domain: "timeline-report-${{ github.ref_name }}"
         domain_name: bitovi-jira.com
         app_port: 3000

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -28,6 +28,6 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
-        sub_domain: "timeline-report-PR-${{ github.event.pull_request.number }}"
+        sub_domain: "auto-scheduler-PR-${{ github.event.pull_request.number }}"
         domain_name: bitovi-jira.com
         app_port: 3000

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -24,5 +24,6 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
+        sub-domain: "timeline-report-${{ github.ref_name }}"
         domain_name: bitovi-jira.com
         app_port: 3000

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -24,6 +24,6 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
-        sub_domain: "timeline-report-${{ github.ref_name }}"
+        sub_domain: "timeline-report-PR-${{ github.event.number }}"
         domain_name: bitovi-jira.com
         app_port: 3000

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     if: "!contains(github.head_ref, 'skip-deploy')"
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name }}
+      name: "PR-${{ github.event.pull_request.number }}"
       url: ${{ steps.deploy.outputs.vm_url }}
     steps:
     - id: deploy
@@ -28,6 +28,6 @@ jobs:
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
 
-        sub_domain: "timeline-report-PR-${{ github.event.number }}"
+        sub_domain: "timeline-report-PR-${{ github.event.pull_request.number }}"
         domain_name: bitovi-jira.com
         app_port: 3000

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   EC2-Deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,5 +23,5 @@ jobs:
         dot_env: ${{ secrets.DOT_ENV }}
 
         domain_name: bitovi-jira.com
-        sub_domain: jira-auto-scheduler
+        sub_domain: auto-scheduler
         app_port: 3000

--- a/.github/workflows/destroy-pr.yaml
+++ b/.github/workflows/destroy-pr.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [ closed ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   destroy:
     # if the branch name of the PR does not contain 'skip-deploy'
@@ -30,6 +34,3 @@ jobs:
 
         # Provide a secret called `DOT_ENV` to append environment variables to the .env file
         dot_env: ${{ secrets.DOT_ENV }}
-
-        domain_name: bitovi-jira.com
-        app_port: 3000

--- a/.github/workflows/destroy-pr.yaml
+++ b/.github/workflows/destroy-pr.yaml
@@ -18,7 +18,7 @@ jobs:
     if: "!contains(github.head_ref, 'skip-deploy')"
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name }}
+      name: "PR-${{ github.event.pull_request.number }}"
       url: ${{ steps.deploy.outputs.vm_url }}
     steps:
     - id: destroy


### PR DESCRIPTION
https://bitovi.slack.com/archives/C0452J8G4DD/p1683771854073849

Changes are all to the `.github/workflows` files:

- Removed the 'jira' from `jira-auto-scheduler` sub_domain pararm.
--> The `main` domain will be `https://auto-scheduler.bitovi-jira.com/`
- Enhanced the `environment` naming so they are called `PR-<number>` instead of `<number>/merge`. 
--> PR environments now look like: `https://auto-scheduler-PR-18.bitovi-jira.com/`
- Added `concurrency` block to all workflows - new runs of a workflow will kill active earlier ones.

Pushing this to `main` should result in the app being re-deployed to `auto-scheduler.bitovi-jira.com`

@justinbmeyer: The `CALLBACK_URL` will likely have to be changed in the Jira App configuration.